### PR TITLE
SCAL-589 Printing result.json when parameters is missing

### DIFF
--- a/scalarmSimulationManager.go
+++ b/scalarmSimulationManager.go
@@ -536,7 +536,7 @@ func main() {
 				fmt.Println("[SiM] An error occurred during 'output_reader' execution.")
 				fmt.Println("[SiM] Please check if 'output_reader' executes correctly on the selected infrastructure.")
 				fmt.Printf("[Fatal error] occured during '%v' execution \n", strings.Join(outputReaderCmd.Args, " "))
-				fmt.Printf("[Fatal error] %s\n", err.Error())	
+				fmt.Printf("[Fatal error] %s\n", err.Error())
 				PrintStdoutLog()
 				os.Exit(1)
 			}
@@ -565,6 +565,10 @@ func main() {
 			}
 
 			file.Close()
+		}
+
+		if simulationRunResults.Status == "" || (simulationRunResults.Results == nil && simulationRunResults.Reason == "") {
+			fmt.Printf("[output.json] Missing data in result: %+v\n", simulationRunResults)
 		}
 
 		// 4f. upload structural results of a simulation run

--- a/scalarmSimulationManager.go
+++ b/scalarmSimulationManager.go
@@ -46,7 +46,7 @@ type SimulationRunResults struct {
 }
 
 func (res *SimulationRunResults) isValid() bool {
-	return !(res.Status == "ok" && res.Results != nil) && !(res.Status == "error" && res.Reason != "")
+	return (res.Status == "ok" && res.Results != nil) || (res.Status == "error" && res.Reason != "")
 }
 
 type RequestInfo struct {
@@ -578,7 +578,7 @@ func main() {
 
 		resultJson, _ := json.Marshal(simulationRunResults.Results)
 
-		if simulationRunResults.isValid() || !isJSON(string(resultJson)) {
+		if !simulationRunResults.isValid() || !isJSON(string(resultJson)) {
 			fmt.Printf("[output.json] Invalid results.json: %s\n", resultJson)
 			simulationRunResults.Status = "error"
 			simulationRunResults.Results = nil


### PR DESCRIPTION
Dodałem wypis struktury pobieranej z output.json kiedy brakuje parametrów, jednak prawie identyczny wypis istniał już wcześniej (linia 581 fmt.Printf("[SiM] Results: %v\n", data)), nie było widać czy nie ma dodatkowych parametrów ale było widać których brakuje. Przykładowy wypis kiedy brakuje result:

[SiM] Results: map[status:[ok] reason:[] result:[null]]
